### PR TITLE
Fix cross AWS region requests

### DIFF
--- a/agent/.dockerignore
+++ b/agent/.dockerignore
@@ -1,7 +1,6 @@
 tmp
 
 target
-!target/debian
 
 .env
 

--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "iam-ssh-agent"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "base64 0.11.0",
  "clap",

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iam-ssh-agent"
 description = "ssh-agent compatible daemon that forwards list-keys and sign-data operations to an API Gateway backend, access controlled by the caller's IAM identity."
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Keith Duncan <keith_duncan@me.com>"]
 edition = "2018"
 repository = "https://github.com/keithduncan/iam-ssh-agent"

--- a/agent/script/client
+++ b/agent/script/client
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec docker run --rm -it --entrypoint bash -v ssh-socket:/ssh --env SSH_AUTH_SOCK=/ssh/socket buildkite-agent
+exec docker run --rm -it --entrypoint bash -v ssh-socket:/ssh --env SSH_AUTH_SOCK=/ssh/socket buildkite/agent

--- a/agent/script/server
+++ b/agent/script/server
@@ -2,4 +2,4 @@
 
 source .env
 
-exec docker run --rm --volume ssh-socket:/ssh --env RUST_LOG=rusoto=debug,hyper=debug --env IAM_SSH_AGENT_BACKEND_URL --env AWS_DEFAULT_REGION --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_SESSION_TOKEN iam-ssh-agent:latest /bin/iam-ssh-agent daemon --bind-to=/ssh/socket
+exec docker run --rm --volume ssh-socket:/ssh --env RUST_LOG=rusoto=debug,hyper=debug --env IAM_SSH_AGENT_BACKEND_URL --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_SESSION_TOKEN iam-ssh-agent:latest /bin/iam-ssh-agent daemon --bind-to=/ssh/socket


### PR DESCRIPTION
When running outside `us-east-1` (your first mistake) we still need to sign requests for a `us-east-1` API Gateway with that region. Using `Region::default()` was always incorrect, but masked by my testing all being in the same region.