### PR TITLE
Add cargo-rpm config files

### DIFF
--- a/agent/.rpm/iam-ssh-agent.spec
+++ b/agent/.rpm/iam-ssh-agent.spec
@@ -1,0 +1,31 @@
+%define __spec_install_post %{nil}
+%define __os_install_post %{_dbpath}/brp-compress
+%define debug_package %{nil}
+
+Name: iam-ssh-agent
+Summary: ssh-agent compatible daemon that forwards list-keys and sign-data operations to an API Gateway backend, access controlled by the caller's IAM identity.
+Version: @@VERSION@@
+Release: @@RELEASE@@
+License: BSD
+Group: Applications/System
+Source0: %{name}-%{version}.tar.gz
+
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
+
+%description
+%{summary}
+
+%prep
+%setup -q
+
+%install
+rm -rf %{buildroot}
+mkdir -p %{buildroot}
+cp -a * %{buildroot}
+
+%clean
+rm -rf %{buildroot}
+
+%files
+%defattr(-,root,root,-)
+%{_bindir}/*

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -26,3 +26,9 @@ openssh-keys = "0.4.1"
 base64 = "0.11.0"
 env_logger = "0.7.1"
 signal-hook = "0.1.13"
+
+[package.metadata.rpm.cargo]
+buildflags = ["--release"]
+
+[package.metadata.rpm.targets]
+iam-ssh-agent = { path = "/usr/bin/iam-ssh-agent" }


### PR DESCRIPTION
Allows building an rpm package to install on Amazon Linux.